### PR TITLE
Proposed README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :triangular_ruler: Sketch Constraints 1.0
 
-Sketch Constraints is a plugin for Sketch that provides a means to create more constraint-based, responsive designs. It is based on Auto Layout constraints.
+Sketch Constraints is a Sketch plugin that provides a means to create more constraint-based, responsive designs. It is based on Auto Layout constraints.
 
 :package: [Download Plugin (Zipped)](https://github.com/matt-curtis/Sketch-Constraints/releases/download/v1.0/Sketch-Constraints.sketchplugin.zip) | :arrow_down: [Download the Example Sketch Document](https://github.com/matt-curtis/Sketch-Constraints/raw/master/Constraint%20Demos.sketch)
 --- | ---
@@ -19,18 +19,18 @@ Sketch Constraints is a plugin for Sketch that provides a means to create more c
 
 - Pin, Offset, Center, and Size relative to Parent Group, Parent Artboard, or Previous Sibling Layer.
 - Utilize simple mathematic expressions as values, such as `50% - 10`
-- View your artboards at different sizes using Preview Mode [**](#preview-mode)
+- View your artboards at different sizes (Mobile, Tablet, Desktop) using Preview Mode [**](#preview-mode)
 - Constraints are stored directly on a layer, so no worries with layer names.
 
 # Usage
 
-First and foremost, I recommend downloading the example Sketch document included in this repo and linked to above. I've included several examples there, and examining the constraints used and playing around (ie. changing constraints, resizing Artboards and pressing `Update Layout`) makes things clearer.
+First and foremost, we recommend downloading the example Sketch document included in this repo (linked to it above). There are several examples included there, and examining the constraints used and playing around with the different options (i.e. Changing constraints, re-sizing artboards and pressing `Update Layout`) makes things clearer.
 
-There are 4 primary actions: Show/Hide Toolbar, Update Layout, Edit Constraints and Preview. All of the features that the plugin provides are available via `Plugins > Sketch Constraints`.
+There are 4 primary actions: Show/Hide Toolbar, Update Layout, Edit Constraints and Preview. All of the features the plugin provides are available via `Plugins > Sketch Constraints`.
 
 ### Show/Hide Toolbar (⌃ + ⇧ + T)
 
-For convenience, the plugin also provides a toolbar that floats above the current document, giving you quick access to all actions.
+For convenience, the plugin provides a toolbar that floats above the current document, giving you quick access to all of the above actions.
 
 ![Toolbar](README/toolbar.png)
 
@@ -52,25 +52,25 @@ Adjusts the layers in the current artboard to reflect your constraints.
 
 ![Preview Mode](README/preview-mode.png)
 
-Opens a window that allows you to preview the currently selected artboard at different sizes. See [notes for more info](#preview-mode).
+Opens a window that allows you to preview the currently selected artboard at different sizes (Mobile, Tablet, Desktop). See [notes for more info](#preview-mode).
 
 # Additional Notes
 
 ### Preview Mode
 
-Preview Mode is rather limited at this time - it only allows you to preview artboards at a preset number of sizes: Mobile, Tablet and Desktop. Expanding it to include more presets, custom sizes, as well as zooming are WIP.
+Preview Mode is rather limited at this time, as it only allows you to preview artboards at a preset number of sizes: Mobile, Tablet and Desktop. Expanding it to include more presets, custom sizes, zooming and more are WIP.
 
 ### Width & Height
 
-If you have Fixed Width or Fixed Height checked and leave the value blank, the plugin will lock the width or height to whatever the current height or width is in Sketch. This is useful in some cases where you want to ensure that the height and width don't change. Less useful for groups, where the height and width are equal to the content (see 'Groups' below)
+If you have Fixed Width or Fixed Height checked, and leave the value blank, the plugin will lock the width or height to whatever the current height or width is in Sketch. This is useful in some cases where you want to ensure the height and width do not change. Less useful for groups, where the height and width are equal to the content (see 'Groups' below)
+
+### Groups
+
+Since the width and height of Groups in Sketch are dependent on their sub-layers, this plugin does not actually resize the height or width of a group, as that would distort the layers within it. Rather, it simulates that sizing when calculating the geometry of sub-layers.
 
 ### Symbols
 
 It's worth noting that while constraints you set on a Symbol *itself* will not propagate to other instances of that Symbol, any constraints you set on its *sub-layers* will.
-
-### Groups
-
-Since the width and height of Groups in Sketch are dependent on their sub-layers, this plugin does not actually resize the height or width of a group, as that would distort the layers in it. Rather, it simulates that sizing when calculating the geometry of sub-layers.
 
 ### Text
 
@@ -83,4 +83,4 @@ In order to acheive this, the easiest way is to use the aspect ratio lock in Ske
 
 # Contact
 
-Questions? Comments? Probably unreciprocated declarations of love? Message & follow me Twitter: [@matt_sven](http://twitter.com/matt_sven)
+Questions? Comments? Probably unreciprocated declarations of love for the both of us? Reach out and/or follow us Twitter: [@matt_sven](http://twitter.com/matt_sven) and [@imcatnoone](http://twitter.com/imcatnoone).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # :triangular_ruler: Sketch Constraints 1.0
 
+> *A collaborative project brought to you by [Matt Curtis](https://twitter.com/matt_sven) & [Cat Noone](https://twitter.com/imcatnoone)*
+
 Sketch Constraints is a Sketch plugin that provides a means to create more constraint-based, responsive designs. It is based on Auto Layout constraints.
 
 :package: [Download Plugin (Zipped)](https://github.com/matt-curtis/Sketch-Constraints/releases/download/v1.0/Sketch-Constraints.sketchplugin.zip) | :arrow_down: [Download the Example Sketch Document](https://github.com/matt-curtis/Sketch-Constraints/raw/master/Constraint%20Demos.sketch)


### PR DESCRIPTION
- Small grammatical or typo changes
- Moved 'Groups' above 'Symbols' as you mention "See groups below" in 'Width & Height' and it makes sense to have it come next before folks forget
